### PR TITLE
Added autoscaling configuration and standardise findfriend naming

### DIFF
--- a/backend/autoscaling.json
+++ b/backend/autoscaling.json
@@ -1,0 +1,16 @@
+{
+  "AdjustmentType": "ChangeInCapacity",
+  "MetricAggregationType": "Average",
+  "Cooldown": 60,
+  "StepAdjustments": [
+    {
+      "MetricIntervalLowerBound": 0,
+      "MetricIntervalUpperBound": 25,
+      "ScalingAdjustment": 1
+    },
+    {
+      "MetricIntervalLowerBound": 25,
+      "ScalingAdjustment": 2
+    }
+  ]
+}

--- a/backend/chatService.yml
+++ b/backend/chatService.yml
@@ -1,11 +1,12 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: Deploy a service into an ECS cluster behind a public load balancer.
 Parameters:
   StackName:
     Type: String
     Default: "nusocialife"
-    Description: The name of the parent cluster stack that you created. Necessary
-                 to locate and reference resources created by that stack.
+    Description:
+      The name of the parent cluster stack that you created. Necessary
+      to locate and reference resources created by that stack.
   ServiceName:
     Type: String
     Default: chat
@@ -13,8 +14,9 @@ Parameters:
   ImageUrl:
     Type: String
     Default: public.ecr.aws/a0f1y0x2/chat:latest
-    Description: The url of a docker image that contains the application process that
-                 will handle the traffic for this service
+    Description:
+      The url of a docker image that contains the application process that
+      will handle the traffic for this service
   ContainerPort:
     Type: Number
     Default: 9000
@@ -31,49 +33,49 @@ Parameters:
     Type: String
     Default: "/api/chat*"
     Description: A path on the public load balancer that this service
-                 should be connected to. Use * to send all load balancer
-                 traffic to this service.
+      should be connected to. Use * to send all load balancer
+      traffic to this service.
   Priority:
     Type: Number
     Default: 2
     Description: The priority for the routing rule added to the load balancer.
-                 This only applies if your have multiple services which have been
-                 assigned to different paths on the load balancer.
+      This only applies if your have multiple services which have been
+      assigned to different paths on the load balancer.
   DesiredCount:
     Type: Number
-    Default: 2
+    Default: 1
     Description: How many copies of the service task to run
   Role:
     Type: String
     Default: ""
-    Description: (Optional) An IAM role to give the service's containers if the code within needs to
-                 access other AWS resources like S3 buckets, DynamoDB tables, etc
+    Description:
+      (Optional) An IAM role to give the service's containers if the code within needs to
+      access other AWS resources like S3 buckets, DynamoDB tables, etc
 
 Conditions:
-  HasCustomRole: !Not [ !Equals [!Ref 'Role', ''] ]
+  HasCustomRole: !Not [!Equals [!Ref "Role", ""]]
 
 Resources:
-
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: !Ref 'ServiceName'
-      Cpu: !Ref 'ContainerCpu'
-      Memory: !Ref 'ContainerMemory'
+      Family: !Ref "ServiceName"
+      Cpu: !Ref "ContainerCpu"
+      Memory: !Ref "ContainerMemory"
       TaskRoleArn:
         Fn::If:
-          - 'HasCustomRole'
-          - !Ref 'Role'
+          - "HasCustomRole"
+          - !Ref "Role"
           - !Ref "AWS::NoValue"
       ContainerDefinitions:
-        - Name: !Ref 'ServiceName'
-          Cpu: !Ref 'ContainerCpu'
-          Memory: !Ref 'ContainerMemory'
-          Image: !Ref 'ImageUrl'
+        - Name: !Ref "ServiceName"
+          Cpu: !Ref "ContainerCpu"
+          Memory: !Ref "ContainerMemory"
+          Image: !Ref "ImageUrl"
           PortMappings:
-            - ContainerPort: !Ref 'ContainerPort'
+            - ContainerPort: !Ref "ContainerPort"
 
   # The service. The service is a resource which allows you to run multiple
   # copies of a type of task, and gather up their logs and metrics, as well
@@ -82,19 +84,18 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: LoadBalancerRule
     Properties:
-      ServiceName: !Ref 'ServiceName'
+      ServiceName: !Ref "ServiceName"
       Cluster:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'ClusterName']]
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "ClusterName"]]
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 75
-      DesiredCount: !Ref 'DesiredCount'
-      TaskDefinition: !Ref 'TaskDefinition'
+      DesiredCount: !Ref "DesiredCount"
+      TaskDefinition: !Ref "TaskDefinition"
       LoadBalancers:
-        - ContainerName: !Ref 'ServiceName'
-          ContainerPort: !Ref 'ContainerPort'
-          TargetGroupArn: !Ref 'TargetGroup'
+        - ContainerName: !Ref "ServiceName"
+          ContainerPort: !Ref "ContainerPort"
+          TargetGroupArn: !Ref "TargetGroup"
 
   # A target group. This is used for keeping track of all the tasks, and
   # what IP addresses / port numbers they have. You can query it yourself,
@@ -109,25 +110,23 @@ Resources:
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-      Name: !Ref 'ServiceName'
+      Name: !Ref "ServiceName"
       Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'VPCId']]
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "VPCId"]]
 
   # Create a rule on the load balancer for routing traffic to the target group
   LoadBalancerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:
       Actions:
-        - TargetGroupArn: !Ref 'TargetGroup'
-          Type: 'forward'
+        - TargetGroupArn: !Ref "TargetGroup"
+          Type: "forward"
       Conditions:
         - Field: path-pattern
-          Values: [!Ref 'Path']
+          Values: [!Ref "Path"]
       ListenerArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'PublicListener']]
-      Priority: !Ref 'Priority'
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "PublicListener"]]
+      Priority: !Ref "Priority"

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -35,9 +35,9 @@ aws cloudformation deploy \
    --capabilities CAPABILITY_NAMED_IAM
 
 aws cloudformation deploy \
-   --template-file findFriendService.yml \
+   --template-file findfriendService.yml \
    --region ap-southeast-1 \
-   --stack-name findFriendMicroservice \
+   --stack-name findfriendMicroservice \
    --capabilities CAPABILITY_NAMED_IAM
 
 aws cloudformation deploy \

--- a/backend/findFriendService.yml
+++ b/backend/findFriendService.yml
@@ -1,11 +1,12 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: Deploy a service into an ECS cluster behind a public load balancer.
 Parameters:
   StackName:
     Type: String
     Default: "nusocialife"
-    Description: The name of the parent cluster stack that you created. Necessary
-                 to locate and reference resources created by that stack.
+    Description:
+      The name of the parent cluster stack that you created. Necessary
+      to locate and reference resources created by that stack.
   ServiceName:
     Type: String
     Default: findfriend
@@ -13,8 +14,9 @@ Parameters:
   ImageUrl:
     Type: String
     Default: public.ecr.aws/a0f1y0x2/findfriend:latest
-    Description: The url of a docker image that contains the application process that
-                 will handle the traffic for this service
+    Description:
+      The url of a docker image that contains the application process that
+      will handle the traffic for this service
   ContainerPort:
     Type: Number
     Default: 7000
@@ -29,51 +31,51 @@ Parameters:
     Description: How much memory in megabytes to give the container
   Path:
     Type: String
-    Default: "/api/findFriend*"
+    Default: "/api/findfriend*"
     Description: A path on the public load balancer that this service
-                 should be connected to. Use * to send all load balancer
-                 traffic to this service.
+      should be connected to. Use * to send all load balancer
+      traffic to this service.
   Priority:
     Type: Number
     Default: 3
     Description: The priority for the routing rule added to the load balancer.
-                 This only applies if your have multiple services which have been
-                 assigned to different paths on the load balancer.
+      This only applies if your have multiple services which have been
+      assigned to different paths on the load balancer.
   DesiredCount:
     Type: Number
-    Default: 2
+    Default: 1
     Description: How many copies of the service task to run
   Role:
     Type: String
     Default: ""
-    Description: (Optional) An IAM role to give the service's containers if the code within needs to
-                 access other AWS resources like S3 buckets, DynamoDB tables, etc
+    Description:
+      (Optional) An IAM role to give the service's containers if the code within needs to
+      access other AWS resources like S3 buckets, DynamoDB tables, etc
 
 Conditions:
-  HasCustomRole: !Not [ !Equals [!Ref 'Role', ''] ]
+  HasCustomRole: !Not [!Equals [!Ref "Role", ""]]
 
 Resources:
-
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: !Ref 'ServiceName'
-      Cpu: !Ref 'ContainerCpu'
-      Memory: !Ref 'ContainerMemory'
+      Family: !Ref "ServiceName"
+      Cpu: !Ref "ContainerCpu"
+      Memory: !Ref "ContainerMemory"
       TaskRoleArn:
         Fn::If:
-          - 'HasCustomRole'
-          - !Ref 'Role'
+          - "HasCustomRole"
+          - !Ref "Role"
           - !Ref "AWS::NoValue"
       ContainerDefinitions:
-        - Name: !Ref 'ServiceName'
-          Cpu: !Ref 'ContainerCpu'
-          Memory: !Ref 'ContainerMemory'
-          Image: !Ref 'ImageUrl'
+        - Name: !Ref "ServiceName"
+          Cpu: !Ref "ContainerCpu"
+          Memory: !Ref "ContainerMemory"
+          Image: !Ref "ImageUrl"
           PortMappings:
-            - ContainerPort: !Ref 'ContainerPort'
+            - ContainerPort: !Ref "ContainerPort"
 
   # The service. The service is a resource which allows you to run multiple
   # copies of a type of task, and gather up their logs and metrics, as well
@@ -82,19 +84,18 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: LoadBalancerRule
     Properties:
-      ServiceName: !Ref 'ServiceName'
+      ServiceName: !Ref "ServiceName"
       Cluster:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'ClusterName']]
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "ClusterName"]]
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 75
-      DesiredCount: !Ref 'DesiredCount'
-      TaskDefinition: !Ref 'TaskDefinition'
+      DesiredCount: !Ref "DesiredCount"
+      TaskDefinition: !Ref "TaskDefinition"
       LoadBalancers:
-        - ContainerName: !Ref 'ServiceName'
-          ContainerPort: !Ref 'ContainerPort'
-          TargetGroupArn: !Ref 'TargetGroup'
+        - ContainerName: !Ref "ServiceName"
+          ContainerPort: !Ref "ContainerPort"
+          TargetGroupArn: !Ref "TargetGroup"
 
   # A target group. This is used for keeping track of all the tasks, and
   # what IP addresses / port numbers they have. You can query it yourself,
@@ -109,25 +110,23 @@ Resources:
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-      Name: !Ref 'ServiceName'
+      Name: !Ref "ServiceName"
       Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'VPCId']]
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "VPCId"]]
 
   # Create a rule on the load balancer for routing traffic to the target group
   LoadBalancerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:
       Actions:
-        - TargetGroupArn: !Ref 'TargetGroup'
-          Type: 'forward'
+        - TargetGroupArn: !Ref "TargetGroup"
+          Type: "forward"
       Conditions:
         - Field: path-pattern
-          Values: [!Ref 'Path']
+          Values: [!Ref "Path"]
       ListenerArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'PublicListener']]
-      Priority: !Ref 'Priority'
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "PublicListener"]]
+      Priority: !Ref "Priority"

--- a/backend/findfriend/src/App.js
+++ b/backend/findfriend/src/App.js
@@ -1,4 +1,4 @@
-import Router from "./routes/findFriendRoutes.js";
+import Router from "./routes/findfriendRoutes.js";
 import express from "express";
 import cors from "cors";
 import { PORT } from "./config/config.js";

--- a/backend/findfriend/src/controllers/findFriendController.js
+++ b/backend/findfriend/src/controllers/findFriendController.js
@@ -1,4 +1,4 @@
-import findFriendService from "../services/findFriendService.js";
+import findFriendService from "../services/findfriendService.js";
 import userAuth from "../middlewares/userAuth.js";
 
 const index = [
@@ -15,7 +15,7 @@ const index = [
 			} else {
 				return res.status(200).json({
 					status: "success",
-					msg: "FindFind Users retrieved successfully",
+					msg: "FindFriend Users retrieved successfully",
 					data: findFriendUsers,
 				});
 			}

--- a/backend/findfriend/src/routes/findFriendRoutes.js
+++ b/backend/findfriend/src/routes/findFriendRoutes.js
@@ -1,5 +1,5 @@
 import express from "express";
-import findFriendController from "../controllers/findFriendController.js";
+import findFriendController from "../controllers/findfriendController.js";
 
 const router = express.Router();
 
@@ -11,7 +11,7 @@ router.get("/health", (req, res) => {
 	});
 });
 
-router.get("/api/findFriend", (req, res) => {
+router.get("/api/findfriend", (req, res) => {
 	res.json({
 		status: "API Its Working",
 		message: "NUSociaLife FindFriend Microservice",
@@ -19,15 +19,15 @@ router.get("/api/findFriend", (req, res) => {
 });
 
 router
-	.route("/api/findFriend/getAllFindFriendUsers")
+	.route("/api/findfriend/getAllFindFriendUsers")
 	.get(findFriendController.index);
 
 router
-	.route("/api/findFriend/clearMatch")
+	.route("/api/findfriend/clearMatch")
 	.post(findFriendController.clearMatch);
 
 router
-	.route("/api/findFriend/createMatch")
+	.route("/api/findfriend/createMatch")
 	.post(findFriendController.createMatch);
 
 export default router;

--- a/backend/findfriend/src/services/findFriendService.js
+++ b/backend/findfriend/src/services/findFriendService.js
@@ -1,5 +1,5 @@
 import mongoose from "mongoose";
-import FindFriend from "../models/findFriendModel.js";
+import FindFriend from "../models/findfriendModel.js";
 import Room from "../models/roomModel.js";
 
 async function getAllFindFriendsUsers() {

--- a/backend/forumService.yml
+++ b/backend/forumService.yml
@@ -1,11 +1,12 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: Deploy a service into an ECS cluster behind a public load balancer.
 Parameters:
   StackName:
     Type: String
     Default: "nusocialife"
-    Description: The name of the parent cluster stack that you created. Necessary
-                 to locate and reference resources created by that stack.
+    Description:
+      The name of the parent cluster stack that you created. Necessary
+      to locate and reference resources created by that stack.
   ServiceName:
     Type: String
     Default: forum
@@ -13,8 +14,9 @@ Parameters:
   ImageUrl:
     Type: String
     Default: public.ecr.aws/a0f1y0x2/forum:latest
-    Description: The url of a docker image that contains the application process that
-                 will handle the traffic for this service
+    Description:
+      The url of a docker image that contains the application process that
+      will handle the traffic for this service
   ContainerPort:
     Type: Number
     Default: 4000
@@ -31,49 +33,49 @@ Parameters:
     Type: String
     Default: "/api/forum*"
     Description: A path on the public load balancer that this service
-                 should be connected to. Use * to send all load balancer
-                 traffic to this service.
+      should be connected to. Use * to send all load balancer
+      traffic to this service.
   Priority:
     Type: Number
     Default: 4
     Description: The priority for the routing rule added to the load balancer.
-                 This only applies if your have multiple services which have been
-                 assigned to different paths on the load balancer.
+      This only applies if your have multiple services which have been
+      assigned to different paths on the load balancer.
   DesiredCount:
     Type: Number
-    Default: 2
+    Default: 1
     Description: How many copies of the service task to run
   Role:
     Type: String
     Default: ""
-    Description: (Optional) An IAM role to give the service's containers if the code within needs to
-                 access other AWS resources like S3 buckets, DynamoDB tables, etc
+    Description:
+      (Optional) An IAM role to give the service's containers if the code within needs to
+      access other AWS resources like S3 buckets, DynamoDB tables, etc
 
 Conditions:
-  HasCustomRole: !Not [ !Equals [!Ref 'Role', ''] ]
+  HasCustomRole: !Not [!Equals [!Ref "Role", ""]]
 
 Resources:
-
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: !Ref 'ServiceName'
-      Cpu: !Ref 'ContainerCpu'
-      Memory: !Ref 'ContainerMemory'
+      Family: !Ref "ServiceName"
+      Cpu: !Ref "ContainerCpu"
+      Memory: !Ref "ContainerMemory"
       TaskRoleArn:
         Fn::If:
-          - 'HasCustomRole'
-          - !Ref 'Role'
+          - "HasCustomRole"
+          - !Ref "Role"
           - !Ref "AWS::NoValue"
       ContainerDefinitions:
-        - Name: !Ref 'ServiceName'
-          Cpu: !Ref 'ContainerCpu'
-          Memory: !Ref 'ContainerMemory'
-          Image: !Ref 'ImageUrl'
+        - Name: !Ref "ServiceName"
+          Cpu: !Ref "ContainerCpu"
+          Memory: !Ref "ContainerMemory"
+          Image: !Ref "ImageUrl"
           PortMappings:
-            - ContainerPort: !Ref 'ContainerPort'
+            - ContainerPort: !Ref "ContainerPort"
 
   # The service. The service is a resource which allows you to run multiple
   # copies of a type of task, and gather up their logs and metrics, as well
@@ -82,19 +84,18 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: LoadBalancerRule
     Properties:
-      ServiceName: !Ref 'ServiceName'
+      ServiceName: !Ref "ServiceName"
       Cluster:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'ClusterName']]
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "ClusterName"]]
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 75
-      DesiredCount: !Ref 'DesiredCount'
-      TaskDefinition: !Ref 'TaskDefinition'
+      DesiredCount: !Ref "DesiredCount"
+      TaskDefinition: !Ref "TaskDefinition"
       LoadBalancers:
-        - ContainerName: !Ref 'ServiceName'
-          ContainerPort: !Ref 'ContainerPort'
-          TargetGroupArn: !Ref 'TargetGroup'
+        - ContainerName: !Ref "ServiceName"
+          ContainerPort: !Ref "ContainerPort"
+          TargetGroupArn: !Ref "TargetGroup"
 
   # A target group. This is used for keeping track of all the tasks, and
   # what IP addresses / port numbers they have. You can query it yourself,
@@ -109,25 +110,23 @@ Resources:
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-      Name: !Ref 'ServiceName'
+      Name: !Ref "ServiceName"
       Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'VPCId']]
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "VPCId"]]
 
   # Create a rule on the load balancer for routing traffic to the target group
   LoadBalancerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:
       Actions:
-        - TargetGroupArn: !Ref 'TargetGroup'
-          Type: 'forward'
+        - TargetGroupArn: !Ref "TargetGroup"
+          Type: "forward"
       Conditions:
         - Field: path-pattern
-          Values: [!Ref 'Path']
+          Values: [!Ref "Path"]
       ListenerArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'PublicListener']]
-      Priority: !Ref 'Priority'
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "PublicListener"]]
+      Priority: !Ref "Priority"

--- a/backend/userService.yml
+++ b/backend/userService.yml
@@ -1,11 +1,12 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: Deploy a service into an ECS cluster behind a public load balancer.
 Parameters:
   StackName:
     Type: String
     Default: "nusocialife"
-    Description: The name of the parent cluster stack that you created. Necessary
-                 to locate and reference resources created by that stack.
+    Description:
+      The name of the parent cluster stack that you created. Necessary
+      to locate and reference resources created by that stack.
   ServiceName:
     Type: String
     Default: users
@@ -13,8 +14,9 @@ Parameters:
   ImageUrl:
     Type: String
     Default: public.ecr.aws/a0f1y0x2/users:latest
-    Description: The url of a docker image that contains the application process that
-                 will handle the traffic for this service
+    Description:
+      The url of a docker image that contains the application process that
+      will handle the traffic for this service
   ContainerPort:
     Type: Number
     Default: 5000
@@ -31,49 +33,49 @@ Parameters:
     Type: String
     Default: "/api/users*"
     Description: A path on the public load balancer that this service
-                 should be connected to. Use * to send all load balancer
-                 traffic to this service.
+      should be connected to. Use * to send all load balancer
+      traffic to this service.
   Priority:
     Type: Number
     Default: 5
     Description: The priority for the routing rule added to the load balancer.
-                 This only applies if your have multiple services which have been
-                 assigned to different paths on the load balancer.
+      This only applies if your have multiple services which have been
+      assigned to different paths on the load balancer.
   DesiredCount:
     Type: Number
-    Default: 2
+    Default: 1
     Description: How many copies of the service task to run
   Role:
     Type: String
     Default: ""
-    Description: (Optional) An IAM role to give the service's containers if the code within needs to
-                 access other AWS resources like S3 buckets, DynamoDB tables, etc
+    Description:
+      (Optional) An IAM role to give the service's containers if the code within needs to
+      access other AWS resources like S3 buckets, DynamoDB tables, etc
 
 Conditions:
-  HasCustomRole: !Not [ !Equals [!Ref 'Role', ''] ]
+  HasCustomRole: !Not [!Equals [!Ref "Role", ""]]
 
 Resources:
-
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: !Ref 'ServiceName'
-      Cpu: !Ref 'ContainerCpu'
-      Memory: !Ref 'ContainerMemory'
+      Family: !Ref "ServiceName"
+      Cpu: !Ref "ContainerCpu"
+      Memory: !Ref "ContainerMemory"
       TaskRoleArn:
         Fn::If:
-          - 'HasCustomRole'
-          - !Ref 'Role'
+          - "HasCustomRole"
+          - !Ref "Role"
           - !Ref "AWS::NoValue"
       ContainerDefinitions:
-        - Name: !Ref 'ServiceName'
-          Cpu: !Ref 'ContainerCpu'
-          Memory: !Ref 'ContainerMemory'
-          Image: !Ref 'ImageUrl'
+        - Name: !Ref "ServiceName"
+          Cpu: !Ref "ContainerCpu"
+          Memory: !Ref "ContainerMemory"
+          Image: !Ref "ImageUrl"
           PortMappings:
-            - ContainerPort: !Ref 'ContainerPort'
+            - ContainerPort: !Ref "ContainerPort"
 
   # The service. The service is a resource which allows you to run multiple
   # copies of a type of task, and gather up their logs and metrics, as well
@@ -82,19 +84,18 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: LoadBalancerRule
     Properties:
-      ServiceName: !Ref 'ServiceName'
+      ServiceName: !Ref "ServiceName"
       Cluster:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'ClusterName']]
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "ClusterName"]]
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 75
-      DesiredCount: !Ref 'DesiredCount'
-      TaskDefinition: !Ref 'TaskDefinition'
+      DesiredCount: !Ref "DesiredCount"
+      TaskDefinition: !Ref "TaskDefinition"
       LoadBalancers:
-        - ContainerName: !Ref 'ServiceName'
-          ContainerPort: !Ref 'ContainerPort'
-          TargetGroupArn: !Ref 'TargetGroup'
+        - ContainerName: !Ref "ServiceName"
+          ContainerPort: !Ref "ContainerPort"
+          TargetGroupArn: !Ref "TargetGroup"
 
   # A target group. This is used for keeping track of all the tasks, and
   # what IP addresses / port numbers they have. You can query it yourself,
@@ -109,25 +110,23 @@ Resources:
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-      Name: !Ref 'ServiceName'
+      Name: !Ref "ServiceName"
       Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'VPCId']]
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "VPCId"]]
 
   # Create a rule on the load balancer for routing traffic to the target group
   LoadBalancerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
     Properties:
       Actions:
-        - TargetGroupArn: !Ref 'TargetGroup'
-          Type: 'forward'
+        - TargetGroupArn: !Ref "TargetGroup"
+          Type: "forward"
       Conditions:
         - Field: path-pattern
-          Values: [!Ref 'Path']
+          Values: [!Ref "Path"]
       ListenerArn:
-        Fn::ImportValue:
-          !Join [':', [!Ref 'StackName', 'PublicListener']]
-      Priority: !Ref 'Priority'
+        Fn::ImportValue: !Join [":", [!Ref "StackName", "PublicListener"]]
+      Priority: !Ref "Priority"


### PR DESCRIPTION
Added autoscaling configuration and standardise findfriend naming
even for api routes to be all small letters.

Docker and github actions all use small letter conventions 
so it is better to follow to avoid further confusion